### PR TITLE
Improve archive.org site ripper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.cdx.json
+.downloaded.txt

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
 # archiveorg_site_ripper
-An archive.org website ripper for ripping specific archive.org websites and saving them with their original html and folder structure in place
+
+A small Python tool for ripping individual pages from the Internet Archive and recreating their original structure locally.
+
+Features:
+
+- Downloads the snapshot page and all referenced assets
+- Strips the Wayback toolbar and injected scripts
+- Removes archive.org comments from HTML, CSS and JavaScript
+- Rewrites asset paths to relative locations and cleans links back to the original URLs
+- Stores the main page with `.html` appended
+
+## Requirements
+
+- Python 3.9+
+- `requests` and `beautifulsoup4`
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the ripper with a direct archive.org URL. The page and all its assets are downloaded to the `output/` directory by default. The downloaded page is saved with `.html` appended to the original file name.
+
+```bash
+python ripper.py https://web.archive.org/web/20210101010101/https://example.com/index.html
+```
+
+Use `-o` to select a different output directory.
+
+```bash
+python ripper.py <archive url> -o mydir
+```
+
+Increase `-c/--concurrency` to download assets in parallel. The default of `1`
+fetches one file at a time, but higher values speed up large pages:
+
+```bash
+python ripper.py <archive url> -c 10
+```
+
+The tool caches the snapshot index (`snapshot.cdx.json`) and records completed
+downloads in `.downloaded.txt`. Re-running the same command resumes where it
+left off. Use `--reset` to clear the cache and start fresh.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/ripper.py
+++ b/ripper.py
@@ -1,0 +1,312 @@
+import argparse
+import os
+import re
+import json
+import time
+import threading
+import requests
+import concurrent.futures
+from bs4 import BeautifulSoup, Comment
+from urllib.parse import urlparse, urljoin
+import hashlib
+
+
+ARCHIVE_PREFIX = 'https://web.archive.org/web/'
+
+# Connection and retry tuning
+CONNECTION_POOL_SIZE = 5
+MAX_RETRIES = 3
+RETRY_DELAY = 2
+RATE_LIMIT = 1
+
+# Configure shared HTTP session with a connection pool
+session = requests.Session()
+adapter = requests.adapters.HTTPAdapter(
+    pool_connections=CONNECTION_POOL_SIZE,
+    pool_maxsize=CONNECTION_POOL_SIZE,
+)
+session.mount('http://', adapter)
+session.mount('https://', adapter)
+
+# File types that are likely textual and can be cleaned of Wayback comments
+TEXT_EXTS = {'.css', '.js', '.html', '.htm', '.svg', '.json', '.xml', '.txt'}
+
+# Tags that contain asset URLs we want to download locally
+SRC_ASSET_TAGS = {
+    'img', 'script', 'iframe', 'embed', 'source', 'audio',
+    'video', 'track', 'object'
+}
+HREF_ASSET_TAGS = {'link'}
+
+
+def parse_archive_url(url: str):
+    match = re.match(r'^https?://web\.archive\.org/web/(\d+)[^/]*/(https?://.*)$', url)
+    if not match:
+        raise ValueError('URL is not a direct archive.org snapshot')
+    timestamp, original = match.groups()
+    return timestamp, original
+
+
+def strip_archive_comments(text: str) -> str:
+    pattern_js = re.compile(r'/\*.*?(?:wayback|archive).*?\*/\s*$', re.DOTALL | re.IGNORECASE)
+    pattern_html = re.compile(r'<!--.*?(?:wayback|archive).*?-->\s*$', re.DOTALL | re.IGNORECASE)
+    text = pattern_js.sub('', text)
+    text = pattern_html.sub('', text)
+    return text
+
+
+def save_file(content: bytes, path: str):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'wb') as f:
+        f.write(content)
+
+
+def fetch_url(url: str) -> bytes:
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            resp = session.get(url)
+            resp.raise_for_status()
+            time.sleep(RATE_LIMIT)
+            return resp.content
+        except Exception:
+            if attempt == MAX_RETRIES:
+                raise
+            time.sleep(RETRY_DELAY)
+
+
+def compute_local_path(output_dir: str, original_url: str, add_ext: bool = False) -> str:
+    parsed = urlparse(original_url)
+    path = parsed.path
+    if path.endswith('/'):
+        path += 'index.html'
+    local = os.path.join(output_dir, parsed.netloc, path.lstrip('/'))
+    if parsed.query:
+        h = hashlib.md5(parsed.query.encode()).hexdigest()[:8]
+        base, ext = os.path.splitext(local)
+        local = base + '_' + h + ext
+    if add_ext:
+        local = local + '.html'
+    return local
+
+
+def get_snapshot_list(original_url: str, output_dir: str):
+    """Fetch or load the Wayback snapshot index."""
+    path = os.path.join(output_dir, 'snapshot.cdx.json')
+    if os.path.exists(path):
+        with open(path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    url = f'https://web.archive.org/cdx/search/cdx?url={original_url}&output=json'
+    data = fetch_url(url).decode('utf-8', 'ignore')
+    os.makedirs(output_dir, exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(data)
+    return json.loads(data)
+
+
+def load_downloaded(output_dir: str):
+    path = os.path.join(output_dir, '.downloaded.txt')
+    if not os.path.exists(path):
+        return set()
+    with open(path, 'r', encoding='utf-8') as f:
+        return set(line.strip() for line in f if line.strip())
+
+
+def mark_downloaded(output_dir: str, url: str, lock: threading.Lock, downloaded: set):
+    path = os.path.join(output_dir, '.downloaded.txt')
+    with lock:
+        if url in downloaded:
+            return
+        downloaded.add(url)
+        with open(path, 'a', encoding='utf-8') as f:
+            f.write(url + '\n')
+
+
+def make_archive_url(timestamp: str, original_url: str) -> str:
+    return f"{ARCHIVE_PREFIX}{timestamp}/{original_url}"
+
+
+def process_asset(
+    asset_url: str,
+    page_dir: str,
+    output_dir: str,
+    timestamp: str,
+    downloaded: set,
+    lock: threading.Lock,
+) -> str:
+    original = asset_url
+    local_path = compute_local_path(output_dir, original)
+    if original in downloaded or os.path.exists(local_path):
+        return os.path.relpath(local_path, page_dir)
+
+    archive_url = make_archive_url(timestamp, original)
+    try:
+        data = fetch_url(archive_url)
+        ext = os.path.splitext(urlparse(original).path)[1].lower()
+        if ext in TEXT_EXTS:
+            text = data.decode('utf-8', 'ignore')
+            text = strip_archive_comments(text)
+            data = text.encode('utf-8')
+        save_file(data, local_path)
+        mark_downloaded(output_dir, original, lock, downloaded)
+    except Exception:
+        pass
+    return os.path.relpath(local_path, page_dir)
+
+
+def process_html(
+    html: str,
+    original_url: str,
+    timestamp: str,
+    output_dir: str,
+    concurrency: int,
+    downloaded: set,
+    lock: threading.Lock,
+) -> str:
+    soup = BeautifulSoup(html, 'html.parser')
+    # remove wayback toolbar
+    wb = soup.find(id='wm-ipp')
+    if wb:
+        wb.decompose()
+    for s in soup.find_all('script'):
+        src = s.get('src', '')
+        text = s.string or ''
+        if (
+            'archive.org' in src
+            or 'wayback' in src
+            or 'wayback' in text.lower()
+            or 'archive' in text.lower()
+        ):
+            s.decompose()
+    for c in soup.find_all(string=lambda t: isinstance(t, Comment)):
+        if 'archive' in c.lower() or 'wayback' in c.lower():
+            c.extract()
+
+    page_local = compute_local_path(output_dir, original_url, add_ext=True)
+    page_dir = os.path.dirname(page_local)
+
+    def prepare_asset(tag, attr, collection):
+        url = tag.get(attr)
+        if not url or url.startswith('data:'):
+            return
+        abs_url = urljoin(original_url, url)
+        if 'web.archive.org' in abs_url:
+            try:
+                _, abs_url = parse_archive_url(abs_url)
+            except ValueError:
+                tag.decompose()
+                return
+        if abs_url.startswith('http'):
+            collection.append((tag, attr, abs_url))
+
+    def rewrite_link(tag, attr):
+        url = tag.get(attr)
+        if not url or url.startswith('data:'):
+            return
+        abs_url = urljoin(original_url, url)
+        if 'web.archive.org' in abs_url:
+            try:
+                _, abs_url = parse_archive_url(abs_url)
+            except ValueError:
+                tag[attr] = abs_url
+                return
+        tag[attr] = abs_url
+
+    assets = []
+    for t in soup.find_all(src=True):
+        if t.name in SRC_ASSET_TAGS:
+            prepare_asset(t, 'src', assets)
+    for t in soup.find_all(href=True):
+        if t.name in HREF_ASSET_TAGS:
+            prepare_asset(t, 'href', assets)
+        elif t.name == 'a':
+            rewrite_link(t, 'href')
+
+    if assets:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as ex:
+            mapping = {
+                ex.submit(
+                    process_asset,
+                    url,
+                    page_dir,
+                    output_dir,
+                    timestamp,
+                    downloaded,
+                    lock,
+                ): (tag, attr)
+                for tag, attr, url in assets
+            }
+            for fut in concurrent.futures.as_completed(mapping):
+                tag, attr = mapping[fut]
+                try:
+                    tag[attr] = fut.result()
+                except Exception:
+                    tag.decompose()
+    for t in soup.find_all(attrs={'srcset': True}):
+        srcset = []
+        for part in t['srcset'].split(','):
+            url_part = part.strip().split(' ')
+            abs_url = urljoin(original_url, url_part[0])
+            if 'web.archive.org' in abs_url:
+                try:
+                    _, abs_url = parse_archive_url(abs_url)
+                except ValueError:
+                    t.decompose()
+                    srcset = []
+                    break
+            rel = process_asset(
+                abs_url,
+                page_dir,
+                output_dir,
+                timestamp,
+                downloaded,
+                lock,
+            )
+            url_part[0] = rel
+            srcset.append(' '.join(url_part))
+        if srcset:
+            t['srcset'] = ', '.join(srcset)
+
+    html = str(soup)
+    html = strip_archive_comments(html)
+    save_file(html.encode('utf-8'), page_local)
+    return page_local
+
+
+def download_page(archive_url: str, output_dir: str, concurrency: int):
+    timestamp, original_url = parse_archive_url(archive_url)
+    get_snapshot_list(original_url, output_dir)
+    downloaded = load_downloaded(output_dir)
+    lock = threading.Lock()
+
+    html_bytes = fetch_url(archive_url)
+    html = html_bytes.decode('utf-8', 'ignore')
+    local_page = process_html(
+        html,
+        original_url,
+        timestamp,
+        output_dir,
+        concurrency,
+        downloaded,
+        lock,
+    )
+    return local_page
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Archive.org site ripper')
+    parser.add_argument('url', help='Direct archive.org URL')
+    parser.add_argument('-o', '--output', default='output', help='Output directory')
+    parser.add_argument('-c', '--concurrency', type=int, default=1, help='Number of parallel downloads')
+    parser.add_argument('--reset', action='store_true', help='Clear cached state before running')
+    args = parser.parse_args()
+    if args.reset:
+        for name in ['snapshot.cdx.json', '.downloaded.txt']:
+            path = os.path.join(args.output, name)
+            if os.path.exists(path):
+                os.remove(path)
+    page = download_page(args.url, args.output, args.concurrency)
+    print(f'Saved page to {page}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- document features in README
- ignore state files in git
- add concurrency, caching, and resuming logic
- expose `--concurrency` and `--reset` flags

## Testing
- `python3 -m py_compile ripper.py`
- `pip install -r requirements.txt`
- `python3 ripper.py --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_686027b7d9ac8330a5d435f60563ff0a