### PR TITLE
Handle asset timestamps and relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,20 @@ A small Python tool for ripping individual pages from the Internet Archive and r
 
 Features:
 
-- Downloads the snapshot page and all referenced assets
+- Downloads the snapshot page and every asset referenced from the HTML, CSS and JavaScript
 - Strips the Wayback toolbar and injected scripts
 - Removes archive.org comments from HTML, CSS and JavaScript
-- Rewrites asset paths to relative locations and cleans links back to the original URLs
+- Rewrites asset and link paths to remove archive.org prefixes and normalize them to simple relative locations when possible; each file is fetched using its own Wayback timestamp if present
+- HTML, CSS and JavaScript files are downloaded using the `id_` form of the Wayback URL so the content is untouched by the archive
+- Removes `<script>` and `<link>` tags that load files from `web-static.archive.org`
+- Scans downloaded CSS and JavaScript for additional resources and rewrites their paths; simple dynamic JavaScript constructions are also parsed so referenced images are fetched
+- Asset paths rewritten inside CSS and JavaScript are normalized to remove any leading slashes and relative path prefixes like `./` or `../`
+- If an asset is missing, the CDX API is queried to find the nearest snapshot
 - Stores the main page with `.html` appended
+- Files are saved directly within the chosen output directory rather than under a domain folder
+- Cleans the HTML before fetching assets so only referenced resources are saved
+- Verifies downloaded files by comparing hashes and retries on mismatch
+- No more than three connections are opened at once, regardless of requested concurrency
 
 ## Requirements
 
@@ -35,8 +44,9 @@ Use `-o` to select a different output directory.
 python ripper.py <archive url> -o mydir
 ```
 
-Increase `-c/--concurrency` to download assets in parallel. The default of `1`
-fetches one file at a time, but higher values speed up large pages:
+Increase `-c/--concurrency` to download assets in parallel. No more than three
+connections are used even if you specify a higher value. The default of `1`
+fetches one file at a time:
 
 ```bash
 python ripper.py <archive url> -c 10

--- a/ripper.py
+++ b/ripper.py
@@ -9,6 +9,7 @@ import concurrent.futures
 from bs4 import BeautifulSoup, Comment
 from urllib.parse import urlparse, urljoin
 import hashlib
+from typing import Optional
 
 
 def log(msg: str):
@@ -19,10 +20,11 @@ def log(msg: str):
 ARCHIVE_PREFIX = 'https://web.archive.org/web/'
 
 # Connection and retry tuning
-CONNECTION_POOL_SIZE = 5
+CONNECTION_POOL_SIZE = 3
 MAX_RETRIES = 3
 RETRY_DELAY = 2
 RATE_LIMIT = 1
+MAX_CONCURRENCY = 3
 
 # Configure shared HTTP session with a connection pool
 session = requests.Session()
@@ -37,6 +39,14 @@ session.headers.update({'User-Agent': 'ArchiveRipper/1.0'})
 # File types that are likely textual and can be cleaned of Wayback comments
 TEXT_EXTS = {'.css', '.js', '.html', '.htm', '.svg', '.json', '.xml', '.txt'}
 
+# Regex patterns to extract asset URLs from CSS and JavaScript files
+CSS_URL_RE = re.compile(r"url\(([^)]+)\)")
+CSS_IMPORT_RE = re.compile(r"@import\s+(?:url\()?['\"]([^'\"]+)['\"]\)?")
+# Common asset extensions that might be referenced from JavaScript
+JS_URL_RE = re.compile(
+    r"['\"]([^'\"]+\.(?:css|js|png|jpe?g|gif|svg|webp|mp4|mp3|webm|woff2?|woff|ttf|eot|otf|json|xml))['\"]"
+)
+
 # Tags that contain asset URLs we want to download locally
 SRC_ASSET_TAGS = {
     'img', 'script', 'iframe', 'embed', 'source', 'audio',
@@ -46,10 +56,14 @@ HREF_ASSET_TAGS = {'link'}
 
 
 def parse_archive_url(url: str):
-    match = re.match(r'^https?://web\.archive\.org/web/(\d+)[^/]*/(https?://.*)$', url)
+    match = re.match(r'^https?://web\.archive\.org/web/(\d+)[^/]*/(.*)$', url)
     if not match:
         raise ValueError('URL is not a direct archive.org snapshot')
-    timestamp, original = match.groups()
+    timestamp, rest = match.groups()
+    idx = rest.rfind('http')
+    if idx == -1:
+        raise ValueError('URL is not a direct archive.org snapshot')
+    original = rest[idx:]
     return timestamp, original
 
 
@@ -87,7 +101,7 @@ def compute_local_path(output_dir: str, original_url: str, add_ext: bool = False
     path = parsed.path
     if path.endswith('/'):
         path += 'index.html'
-    local = os.path.join(output_dir, parsed.netloc, path.lstrip('/'))
+    local = os.path.join(output_dir, path.lstrip('/'))
     if parsed.query:
         h = hashlib.md5(parsed.query.encode()).hexdigest()[:8]
         base, ext = os.path.splitext(local)
@@ -95,6 +109,19 @@ def compute_local_path(output_dir: str, original_url: str, add_ext: bool = False
     if add_ext:
         local = local + '.html'
     return local
+
+
+def clean_rel_path(path: str) -> str:
+    """Remove leading relative path tokens from a URL or file path."""
+    prefixes = ['../', '..\\', './', '.\\', '.', '\\']
+    changed = True
+    while changed:
+        changed = False
+        for p in prefixes:
+            if path.startswith(p):
+                path = path[len(p):]
+                changed = True
+    return path.lstrip('/')
 
 
 
@@ -117,38 +144,298 @@ def mark_downloaded(output_dir: str, url: str, lock: threading.Lock, downloaded:
             f.write(url + '\n')
 
 
-def make_archive_url(timestamp: str, original_url: str) -> str:
+def make_archive_url(timestamp: str, original_url: str, raw: bool = False) -> str:
+    """Construct a Wayback Machine URL for the given timestamp and resource."""
+    if raw:
+        return f"{ARCHIVE_PREFIX}{timestamp}id_/{original_url}"
     return f"{ARCHIVE_PREFIX}{timestamp}/{original_url}"
+
+
+def find_nearest_snapshot(original_url: str, timestamp: str) -> Optional[str]:
+    """Query the CDX API for the closest snapshot of the given URL."""
+    cdx = (
+        "https://web.archive.org/cdx/search/cdx?"\
+        f"url={original_url}&output=json&limit=1"\
+        f"&closest={timestamp}&filter=statuscode:200&fl=timestamp"
+    )
+    try:
+        resp = session.get(cdx)
+        resp.raise_for_status()
+        data = resp.json()
+        if len(data) > 1 and len(data[1]) > 0:
+            return str(data[1][0])
+    except Exception as e:
+        log(f"CDX lookup failed for {original_url}: {e}")
+    return None
+
+
+def rewrite_css(
+    text: str,
+    base_url: str,
+    asset_dir: str,
+    output_dir: str,
+    timestamp: str,
+    downloaded: set,
+    lock: threading.Lock,
+) -> str:
+    def repl_url(match):
+        url = match.group(1).strip().strip("'\"")
+        if url.startswith('data:'):
+            return match.group(0)
+        if url.startswith('/web/'):
+            archive_base = make_archive_url(timestamp, base_url)
+            abs_url = urljoin(archive_base, url)
+        else:
+            abs_url = urljoin(base_url, url)
+        if 'web.archive.org' in abs_url:
+            try:
+                _, abs_url = parse_archive_url(abs_url)
+            except ValueError:
+                return match.group(0)
+        if urlparse(abs_url).netloc == 'web-static.archive.org':
+            return match.group(0)
+        rel = clean_rel_path(
+            process_asset(
+                abs_url,
+                asset_dir,
+                output_dir,
+                timestamp,
+                downloaded,
+                lock,
+            )
+        )
+        return f"url('{rel}')"
+
+    def repl_import(match):
+        url = match.group(1).strip().strip("'\"")
+        if url.startswith('data:'):
+            return match.group(0)
+        if url.startswith('/web/'):
+            archive_base = make_archive_url(timestamp, base_url)
+            abs_url = urljoin(archive_base, url)
+        else:
+            abs_url = urljoin(base_url, url)
+        if 'web.archive.org' in abs_url:
+            try:
+                _, abs_url = parse_archive_url(abs_url)
+            except ValueError:
+                return match.group(0)
+        if urlparse(abs_url).netloc == 'web-static.archive.org':
+            return match.group(0)
+        rel = clean_rel_path(
+            process_asset(
+                abs_url,
+                asset_dir,
+                output_dir,
+                timestamp,
+                downloaded,
+                lock,
+            )
+        )
+        return f"@import url('{rel}')"
+
+    text = CSS_URL_RE.sub(repl_url, text)
+    text = CSS_IMPORT_RE.sub(repl_import, text)
+    return text
+
+
+def rewrite_js(
+    text: str,
+    base_url: str,
+    asset_dir: str,
+    output_dir: str,
+    timestamp: str,
+    downloaded: set,
+    lock: threading.Lock,
+    ) -> str:
+    def repl(match):
+        url = match.group(1)
+        if url.startswith('data:'):
+            return match.group(0)
+        if url.startswith('/web/'):
+            archive_base = make_archive_url(timestamp, base_url)
+            abs_url = urljoin(archive_base, url)
+        else:
+            abs_url = urljoin(base_url, url)
+        if 'web.archive.org' in abs_url:
+            try:
+                _, abs_url = parse_archive_url(abs_url)
+            except ValueError:
+                return match.group(0)
+        if urlparse(abs_url).netloc == 'web-static.archive.org':
+            return match.group(0)
+        rel = clean_rel_path(
+            process_asset(
+                abs_url,
+                asset_dir,
+                output_dir,
+                timestamp,
+                downloaded,
+                lock,
+            )
+        )
+        quote = match.group(0)[0]
+        return f"{quote}{rel}{quote}"
+
+    text = JS_URL_RE.sub(repl, text)
+    text = scan_dynamic_js(
+        text,
+        base_url,
+        asset_dir,
+        output_dir,
+        timestamp,
+        downloaded,
+        lock,
+    )
+    return text
+
+
+def _rel_base_path(base_url: str, base_path: str, asset_dir: str, output_dir: str) -> str:
+    """Return a relative base path for rewriting JS dynamic asset prefixes."""
+    dummy = urljoin(base_url, base_path.lstrip('/') + 'dummy.file')
+    local = compute_local_path(output_dir, dummy)
+    local_dir = os.path.dirname(local)
+    rel = os.path.relpath(local_dir, asset_dir)
+    if not rel.endswith('/'):
+        rel += '/'
+    return clean_rel_path(rel)
+
+
+def scan_dynamic_js(
+    text: str,
+    base_url: str,
+    asset_dir: str,
+    output_dir: str,
+    timestamp: str,
+    downloaded: set,
+    lock: threading.Lock,
+) -> str:
+    """Look for simple dynamic asset constructions inside JavaScript."""
+    base_vars = {}
+
+    def replace_base(match):
+        name = match.group(1)
+        path = match.group(2)
+        base_vars[name] = path
+        rel = clean_rel_path(
+            _rel_base_path(base_url, path, asset_dir, output_dir)
+        )
+        return f'var {name} = "{rel}";'
+
+    text = re.sub(r"var\s+(\w+)\s*=\s*['\"]([^'\"]+)['\"]\s*;", replace_base, text)
+
+    arrays: dict[str, list[str]] = {}
+    for pat in [r"var\s+(\w+)\s*=\s*new\s+Array\(([^)]*)\)", r"var\s+(\w+)\s*=\s*\[([^\]]*)\]"]:
+        for m in re.finditer(pat, text):
+            name = m.group(1)
+            items = re.findall(r"['\"]([^'\"]+)['\"]", m.group(2))
+            arrays[name] = items
+
+    pattern = re.compile(
+        r"(\w+)\s*\+\s*(?:['\"]([^'\"]+)['\"]\s*\+\s*)?(\w+)\[[^\]]+\]\s*\+\s*['\"]([^'\"]+)['\"]"
+    )
+
+    for m in pattern.finditer(text):
+        base_var, prefix, arr_var, ext = m.groups()
+        if base_var not in base_vars or arr_var not in arrays:
+            continue
+        base_path = base_vars[base_var]
+        prefix = prefix or ''
+        for item in arrays[arr_var]:
+            asset = base_path + prefix + item + ext
+            abs_url = urljoin(base_url, asset)
+            process_asset(
+                abs_url,
+                asset_dir,
+                output_dir,
+                timestamp,
+                downloaded,
+                lock,
+            )
+
+    return text
 
 
 def process_asset(
     asset_url: str,
     page_dir: str,
     output_dir: str,
-    timestamp: str,
+    asset_timestamp: str,
     downloaded: set,
     lock: threading.Lock,
 ) -> str:
     original = asset_url
     local_path = compute_local_path(output_dir, original)
     if original in downloaded or os.path.exists(local_path):
-        return os.path.relpath(local_path, page_dir)
+        return clean_rel_path(os.path.relpath(local_path, page_dir))
 
     log(f"Fetching asset {asset_url}")
 
-    archive_url = make_archive_url(timestamp, original)
+    ext = os.path.splitext(urlparse(original).path)[1].lower()
+    raw = ext in {'.css', '.js', '.html', '.htm'} or not ext
+    archive_url = make_archive_url(asset_timestamp, original, raw=raw)
     try:
         data = fetch_url(archive_url)
-        ext = os.path.splitext(urlparse(original).path)[1].lower()
-        if ext in TEXT_EXTS:
-            text = data.decode('utf-8', 'ignore')
-            text = strip_archive_comments(text)
-            data = text.encode('utf-8')
+    except Exception as e:
+        log(f"Failed to fetch {archive_url}: {e}")
+        nearest = find_nearest_snapshot(original, asset_timestamp)
+        if nearest and nearest != asset_timestamp:
+            log(f"Retrying {original} with snapshot {nearest}")
+            archive_url = make_archive_url(nearest, original, raw=raw)
+            try:
+                data = fetch_url(archive_url)
+            except Exception as e2:
+                log(f"Failed alternate snapshot for {asset_url}: {e2}")
+                return asset_url
+        else:
+            return asset_url
+
+    ext = os.path.splitext(urlparse(original).path)[1].lower()
+    if ext in TEXT_EXTS:
+        text = data.decode('utf-8', 'ignore')
+        text = strip_archive_comments(text)
+        asset_dir = os.path.dirname(local_path)
+        if ext == '.css':
+            text = rewrite_css(
+                text,
+                original,
+                asset_dir,
+                output_dir,
+                asset_timestamp,
+                downloaded,
+                lock,
+            )
+        elif ext == '.js':
+            text = rewrite_js(
+                text,
+                original,
+                asset_dir,
+                output_dir,
+                asset_timestamp,
+                downloaded,
+                lock,
+            )
+        data = text.encode('utf-8')
+
+    for attempt in range(1, MAX_RETRIES + 1):
         save_file(data, local_path)
-        mark_downloaded(output_dir, original, lock, downloaded)
-    except Exception:
-        pass
-    return os.path.relpath(local_path, page_dir)
+        expected = hashlib.md5(data).hexdigest()
+        with open(local_path, 'rb') as f:
+            actual = hashlib.md5(f.read()).hexdigest()
+        if expected == actual:
+            break
+        if attempt == MAX_RETRIES:
+            log(f"Hash mismatch for {archive_url}, giving up")
+            break
+        log(f"Hash mismatch for {archive_url}, retrying")
+        time.sleep(RETRY_DELAY)
+        try:
+            data = fetch_url(archive_url)
+        except Exception:
+            break
+
+    mark_downloaded(output_dir, original, lock, downloaded)
+    return clean_rel_path(os.path.relpath(local_path, page_dir))
 
 
 def process_html(
@@ -168,6 +455,15 @@ def process_html(
     for s in soup.find_all('script'):
         src = s.get('src', '')
         text = s.string or ''
+        full_src = urljoin(original_url, src)
+        try:
+            if 'web.archive.org' in full_src:
+                _, full_src = parse_archive_url(full_src)
+        except ValueError:
+            pass
+        if urlparse(full_src).netloc == 'web-static.archive.org':
+            s.decompose()
+            continue
         if (
             'archive.org' in src
             or 'wayback' in src
@@ -175,6 +471,16 @@ def process_html(
             or 'archive' in text.lower()
         ):
             s.decompose()
+    for l in soup.find_all('link', href=True):
+        href = l['href']
+        abs_href = urljoin(original_url, href)
+        try:
+            if 'web.archive.org' in abs_href:
+                _, abs_href = parse_archive_url(abs_href)
+        except ValueError:
+            continue
+        if urlparse(abs_href).netloc == 'web-static.archive.org':
+            l.decompose()
     for c in soup.find_all(string=lambda t: isinstance(t, Comment)):
         if 'archive' in c.lower() or 'wayback' in c.lower():
             c.extract()
@@ -187,27 +493,41 @@ def process_html(
         if not url or url.startswith('data:'):
             return
         abs_url = urljoin(original_url, url)
+        ts = timestamp
         if 'web.archive.org' in abs_url:
             try:
-                _, abs_url = parse_archive_url(abs_url)
+                ts, abs_url = parse_archive_url(abs_url)
             except ValueError:
                 tag.decompose()
                 return
+        if urlparse(abs_url).netloc == 'web-static.archive.org':
+            tag.decompose()
+            return
         if abs_url.startswith('http'):
-            collection.append((tag, attr, abs_url))
+            collection.append((tag, attr, abs_url, ts))
 
     def rewrite_link(tag, attr):
-        url = tag.get(attr)
-        if not url or url.startswith('data:'):
+        val = tag.get(attr)
+        if not val or val.startswith('data:'):
             return
-        abs_url = urljoin(original_url, url)
-        if 'web.archive.org' in abs_url:
+        abs_val = urljoin(original_url, val)
+        if 'web.archive.org' in abs_val:
             try:
-                _, abs_url = parse_archive_url(abs_url)
+                _, abs_val = parse_archive_url(abs_val)
             except ValueError:
-                tag[attr] = abs_url
+                tag[attr] = abs_val
                 return
-        tag[attr] = abs_url
+        parsed_abs = urlparse(abs_val)
+        parsed_base = urlparse(original_url)
+        if parsed_abs.netloc == parsed_base.netloc:
+            new_url = clean_rel_path(parsed_abs.path)
+            if parsed_abs.query:
+                new_url += '?' + parsed_abs.query
+            if parsed_abs.fragment:
+                new_url += '#' + parsed_abs.fragment
+            tag[attr] = new_url
+        else:
+            tag[attr] = abs_val
 
     assets = []
     for t in soup.find_all(src=True):
@@ -227,16 +547,16 @@ def process_html(
                     url,
                     page_dir,
                     output_dir,
-                    timestamp,
+                    ts,
                     downloaded,
                     lock,
                 ): (tag, attr)
-                for tag, attr, url in assets
+                for tag, attr, url, ts in assets
             }
             for fut in concurrent.futures.as_completed(mapping):
                 tag, attr = mapping[fut]
                 try:
-                    tag[attr] = fut.result()
+                    tag[attr] = clean_rel_path(fut.result())
                 except Exception:
                     tag.decompose()
     for t in soup.find_all(attrs={'srcset': True}):
@@ -244,20 +564,27 @@ def process_html(
         for part in t['srcset'].split(','):
             url_part = part.strip().split(' ')
             abs_url = urljoin(original_url, url_part[0])
+            ts = timestamp
             if 'web.archive.org' in abs_url:
                 try:
-                    _, abs_url = parse_archive_url(abs_url)
+                    ts, abs_url = parse_archive_url(abs_url)
                 except ValueError:
                     t.decompose()
                     srcset = []
                     break
-            rel = process_asset(
-                abs_url,
-                page_dir,
-                output_dir,
-                timestamp,
-                downloaded,
-                lock,
+            if urlparse(abs_url).netloc == 'web-static.archive.org':
+                t.decompose()
+                srcset = []
+                break
+            rel = clean_rel_path(
+                process_asset(
+                    abs_url,
+                    page_dir,
+                    output_dir,
+                    ts,
+                    downloaded,
+                    lock,
+                )
             )
             url_part[0] = rel
             srcset.append(' '.join(url_part))
@@ -276,7 +603,8 @@ def download_page(archive_url: str, output_dir: str, concurrency: int):
     lock = threading.Lock()
     log(f"Fetching {original_url} from {archive_url}")
 
-    html_bytes = fetch_url(archive_url)
+    html_url = make_archive_url(timestamp, original_url, raw=True)
+    html_bytes = fetch_url(html_url)
     html = html_bytes.decode('utf-8', 'ignore')
     local_page = process_html(
         html,
@@ -295,14 +623,15 @@ def main():
     parser = argparse.ArgumentParser(description='Archive.org site ripper')
     parser.add_argument('url', help='Direct archive.org URL')
     parser.add_argument('-o', '--output', default='output', help='Output directory')
-    parser.add_argument('-c', '--concurrency', type=int, default=1, help='Number of parallel downloads')
+    parser.add_argument('-c', '--concurrency', type=int, default=1, help='Number of parallel downloads (max 3)')
     parser.add_argument('--reset', action='store_true', help='Clear downloaded log before running')
     args = parser.parse_args()
     if args.reset:
         path = os.path.join(args.output, '.downloaded.txt')
         if os.path.exists(path):
             os.remove(path)
-    page = download_page(args.url, args.output, args.concurrency)
+    conc = min(args.concurrency, MAX_CONCURRENCY)
+    page = download_page(args.url, args.output, conc)
     log(f'Saved page to {page}')
 
 


### PR DESCRIPTION
## Summary
- fetch assets using their own archive timestamps
- remove web-static assets and remove Wayback prefix only after fetching
- recursively scan CSS/JS for more assets
- fetch HTML/CSS/JS using `id_` URLs for clean content
- query the CDX API to find the nearest snapshot when an asset is missing
- verify downloaded files with hashes and retry on mismatch
- cap parallel downloads to at most three connections
- fix typing of `find_nearest_snapshot` for Python < 3.10 compatibility
- fix asset discovery so the ripper downloads resources correctly
- fix link rewriting variable to avoid `UnboundLocalError`
- fix missing slash in archive URL generation
- parse dynamic JavaScript arrays to fetch and rewrite generated images
- normalize CSS/JS asset paths to remove leading slashes
- **strip ./ and ../ prefixes from rewritten paths**
- save assets directly into the specified output directory

## Testing
- `pip install -r requirements.txt`
- `python ripper.py --help`
- `python -m py_compile ripper.py`


------
https://chatgpt.com/codex/tasks/task_e_6860358687888330ac79452cf1aa94e3